### PR TITLE
/\.js?$/ -> /\.jsx?$/

### DIFF
--- a/packages/uxpin-merge-cli/src/resources/uxpin.webpack.config.js
+++ b/packages/uxpin-merge-cli/src/resources/uxpin.webpack.config.js
@@ -30,7 +30,7 @@ module.exports = {
       },
       {
         loader: require.resolve('babel-loader', { paths: ['./node_modules/@uxpin/merge-cli'] }),
-        test: /\.js?$/,
+        test: /\.jsx?$/,
         exclude: /node_modules/,
         options: {
           presets: [


### PR DESCRIPTION
```js
'.jsx'.match(/\.js?$/) // unmatched
'.js'.match(/\.js?$/) // matched
'.j'.match(/\.js?$/) // matched
```
should be
```js
'.jsx'.match(/\.jsx?$/) // matched
'.js'.match(/\.jsx?$/) // matched
'.j'.match(/\.jsx?$/) // unmatched
```